### PR TITLE
feat(devops): containerize backend with Docker — Closes #1.7

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install uv (Rust-based package manager)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Prevent Python from writing .pyc files and enable unbuffered output
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Copy dependency files and install
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen
+
+EXPOSE 8000
+
+CMD ["uv", "run", "python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,47 @@
-version: "3.9"
-
 services:
   db:
-    image: postgres:16
+    image: postgres:16-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: zignature_db
       POSTGRES_USER: zignature_user
       POSTGRES_PASSWORD: zignature_pass
-    ports:
-      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U zignature_user -d zignature_db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
   backend:
     build: ./backend
-    restart: unless-stopped
-    command: uv run python manage.py runserver 0.0.0.0:8000
+    command: sh -c "uv sync --frozen && uv run python manage.py runserver 0.0.0.0:8000"
     volumes:
       - ./backend:/app
+      - backend_venv:/app/.venv
+      - media_files:/app/media
     ports:
       - "8000:8000"
+    env_file: ./backend/.env
     environment:
-      DJANGO_SETTINGS_MODULE: config.settings.development
+      - DB_HOST=db
+      - DJANGO_SETTINGS_MODULE=config.settings.development
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.dev.conf:/etc/nginx/conf.d/default.conf:ro
+      - media_files:/app/media:ro
+    depends_on:
+      - backend
 
 volumes:
   postgres_data:
+  media_files:
+  backend_venv:

--- a/nginx/nginx.dev.conf
+++ b/nginx/nginx.dev.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /media/ {
+        alias /app/media/;
+    }
+}


### PR DESCRIPTION
- Add backend/Dockerfile (Python 3.12-slim + uv)
- Add nginx/nginx.dev.conf (HTTP reverse proxy for local dev)
- Update docker-compose.yml with healthcheck, nginx service, and named volumes
- 5-minute onboarding: docker compose up -d → migrate → ready