### PR TITLE
feat(auth): add Google OAuth2 integration (Ticket 1.4)

### DIFF
--- a/backend/apps/accounts/google.py
+++ b/backend/apps/accounts/google.py
@@ -1,0 +1,175 @@
+"""
+apps/accounts/google.py
+
+Google ID token verification service for Ticket 1.4.
+
+Architecture decisions:
+────────────────────────────────────────────────────────────────
+1. NO django-allauth for this endpoint.
+   django-allauth is designed for server-side OAuth redirects.
+   Our flow is a frontend-driven token exchange — the React frontend
+   gets the id_token from Google directly (@react-oauth/google), then
+   POSTs it here. We verify it ourselves using Google's public key
+   endpoint. This is simpler, faster, and has zero redirect round trips.
+
+2. google-auth library (google-auth[requests]) — the official Google
+   client library — is used for id_token verification. It:
+     • Fetches Google's public keys from the certs endpoint
+     • Caches the public keys in memory until they expire (avoids
+       a Google round-trip on every login — key rotation happens ~24h)
+     • Validates signature, expiry (exp), audience (aud), issuer (iss)
+     • Returns a verified payload dict or raises ValueError
+
+3. 5-second timeout on the Google certs fetch (system.md §13).
+   If Google is unreachable, we raise GoogleServiceUnavailable which
+   the view catches and returns 503. Email/password login is unaffected.
+
+4. The verified payload contains these fields we use:
+     • sub       — Google's unique user ID (stable, never reused)
+     • email     — User's email address
+     • email_verified — Must be True or we reject
+     • name      — Full name (used as display hint)
+     • picture   — Avatar URL (not stored in MVP, logged for future use)
+
+5. We do NOT store Google's `sub` in the User model in Ticket 1.4.
+   The email is the join key. If two providers share an email, they
+   merge into the same account (system.md §13 edge case).
+   Storing `sub` is a Ticket for the hardening phase.
+"""
+
+import logging
+from dataclasses import dataclass
+
+import requests as http_requests
+from django.conf import settings
+from google.auth.exceptions import TransportError
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token
+
+logger = logging.getLogger(__name__)
+
+
+# ── Custom exceptions ─────────────────────────────────────────────────────────
+
+class GoogleServiceUnavailable(Exception):
+    """
+    Raised when Google's token verification endpoint is unreachable or
+    times out. The view catches this and returns 503.
+    """
+
+
+class GoogleTokenInvalid(Exception):
+    """
+    Raised when the id_token fails verification — wrong audience,
+    expired, bad signature, or email_verified=False.
+    """
+
+
+# ── Verified payload dataclass ────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class GoogleUserInfo:
+    """
+    Verified, clean payload from a Google ID token.
+    All fields are validated before this object is constructed.
+    """
+    google_sub: str       # Google's stable user ID
+    email: str            # Normalised lowercase email
+    name: str             # Display name from Google profile
+    picture_url: str      # Avatar URL (not stored in MVP)
+
+
+# ── Verification ──────────────────────────────────────────────────────────────
+
+def verify_google_id_token(raw_id_token: str) -> GoogleUserInfo:
+    """
+    Verify a Google ID token and return clean user info.
+
+    This is the ONLY function the view calls. All Google-specific
+    logic is isolated here — the view never imports google.oauth2.
+
+    Raises:
+        GoogleServiceUnavailable — Google's servers unreachable / timeout
+        GoogleTokenInvalid       — Token is invalid, expired, or wrong audience
+    """
+    client_id = settings.GOOGLE_CLIENT_ID
+
+    if not client_id:
+        raise GoogleTokenInvalid(
+            "GOOGLE_CLIENT_ID is not configured. Cannot verify token."
+        )
+
+    try:
+        # google.oauth2.id_token.verify_oauth2_token:
+        #   1. Fetches Google's public keys (cached until key rotation)
+        #   2. Verifies JWT signature using the correct public key
+        #   3. Validates: exp, iat, iss (accounts.google.com), aud == client_id
+        #   Returns the decoded payload dict if valid, raises ValueError if not.
+        request_adapter = google_requests.Request(
+            session=_build_session_with_timeout()
+        )
+        payload = id_token.verify_oauth2_token(
+            id_token=raw_id_token,
+            request=request_adapter,
+            audience=client_id,
+            clock_skew_in_seconds=10,  # tolerate minor clock drift on servers
+        )
+
+    except TransportError as exc:
+        # Network error — Google's certs endpoint was unreachable or timed out
+        logger.error("Google certs endpoint unreachable: %s", exc)
+        raise GoogleServiceUnavailable(
+            "Google authentication service is currently unavailable."
+        ) from exc
+
+    except ValueError as exc:
+        # Invalid token — bad signature, wrong audience, expired, etc.
+        logger.warning("Google id_token verification failed: %s", exc)
+        raise GoogleTokenInvalid(str(exc)) from exc
+
+    # ── Post-verification checks ──────────────────────────────────────────────
+
+    if not payload.get("email_verified"):
+        raise GoogleTokenInvalid(
+            "Google account email is not verified. "
+            "Please verify your Google account first."
+        )
+
+    email = payload.get("email", "").lower().strip()
+    if not email:
+        raise GoogleTokenInvalid("No email address in Google token payload.")
+
+    return GoogleUserInfo(
+        google_sub=payload["sub"],
+        email=email,
+        name=payload.get("name", ""),
+        picture_url=payload.get("picture", ""),
+    )
+
+
+# ── Private helpers ───────────────────────────────────────────────────────────
+
+def _build_session_with_timeout() -> http_requests.Session:
+    """
+    Returns a requests.Session with a 5-second connect+read timeout
+    (system.md §13: "Verify token against Google's public keys with
+    5-second timeout").
+
+    The google-auth library accepts a session object so we can inject
+    our timeout. Without this, the default is no timeout — a hung Google
+    server would block a Uvicorn worker indefinitely.
+    """
+    session = http_requests.Session()
+    session.request = _timeout_request_factory(session.request, timeout=5)
+    return session
+
+
+def _timeout_request_factory(original_request, timeout: int):
+    """
+    Wraps session.request to inject a timeout without touching
+    google-auth internals.
+    """
+    def request_with_timeout(*args, **kwargs):
+        kwargs.setdefault("timeout", timeout)
+        return original_request(*args, **kwargs)
+    return request_with_timeout

--- a/backend/apps/accounts/serializers.py
+++ b/backend/apps/accounts/serializers.py
@@ -103,3 +103,34 @@ class PasswordChangeSerializer(serializers.Serializer):
                 {"new_password_confirm": "New passwords do not match."},
             )
         return attrs
+
+
+class GoogleLoginSerializer(serializers.Serializer):
+    """
+    Validates the incoming Google id_token from the frontend.
+
+    The frontend receives this token from @react-oauth/google after
+    the user completes the Google consent screen. It's a signed JWT
+    issued by Google — we verify it in google.py.
+
+    We don't validate the token format here (that's google-auth's job).
+    We just confirm the field is present and non-empty.
+    """
+
+    id_token = serializers.CharField(
+        required=True,
+        allow_blank=False,
+        help_text="Google ID token from @react-oauth/google credential response.",
+    )
+
+    def validate_id_token(self, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise serializers.ValidationError("id_token cannot be empty.")
+        # Basic sanity: Google JWTs are always 3-part dot-separated strings
+        if value.count(".") != 2:
+            raise serializers.ValidationError(
+                "id_token does not appear to be a valid JWT. "
+                "Expected a Google credential response token."
+            )
+        return value

--- a/backend/apps/accounts/services.py
+++ b/backend/apps/accounts/services.py
@@ -1,0 +1,112 @@
+"""
+apps/accounts/services.py
+
+Business logic for Google OAuth user get-or-create.
+
+Separated from views.py so it can be tested independently
+and reused (e.g., in a future mobile token endpoint).
+
+This module owns the answer to:
+  "Given a verified GoogleUserInfo, which User account does it map to?"
+"""
+
+import logging
+import uuid
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+
+from .google import GoogleUserInfo
+
+logger = logging.getLogger(__name__)
+
+User = get_user_model()
+
+
+def get_or_create_google_user(info: GoogleUserInfo) -> tuple:
+    """
+    Given a verified Google user payload, return (user, created).
+
+    Logic (system.md §7.2, §13):
+    ─────────────────────────────
+    Case 1 — email already exists in DB:
+        • Return that user regardless of auth_provider.
+        • If auth_provider = 'email', the user is silently upgrading
+          to Google login. We do NOT overwrite auth_provider here —
+          the user still has their email/password. They can use either.
+          (Changing auth_provider would break password change for them.)
+        • Log a warning so the admin can see the merge event.
+
+    Case 2 — email is new:
+        • Create User with auth_provider='google', unusable password.
+        • Username is auto-generated from email prefix + short UUID.
+        • Profile is auto-created by post_save signal (Ticket 1.5).
+        • Return (user, True).
+
+    This runs in a transaction so partial user creation never happens.
+    """
+    email = info.email  # already normalised in verify_google_id_token
+
+    # ── Case 1: Existing user ─────────────────────────────────────────────────
+    try:
+        user = User.objects.get(email=email)
+        if user.auth_provider != User.AuthProvider.GOOGLE:
+            logger.warning(
+                "Google login for email=%s which has auth_provider=%s. "
+                "Allowing login but not changing auth_provider.",
+                email,
+                user.auth_provider,
+            )
+        return user, False
+
+    except User.DoesNotExist:
+        pass
+
+    # ── Case 2: New user ──────────────────────────────────────────────────────
+    with transaction.atomic():
+        username = _generate_username(email)
+        user = User.objects.create(
+            email=email,
+            username=username,
+            auth_provider=User.AuthProvider.GOOGLE,
+            is_active=True,
+        )
+        # Set unusable password — Google users have no password.
+        # user.check_password() will always return False.
+        # PasswordChangeView already blocks this user (is_google_user = True).
+        user.set_unusable_password()
+        user.save(update_fields=["password"])
+
+        logger.info(
+            "New Google user created: email=%s username=%s",
+            email,
+            username,
+        )
+        return user, True
+
+
+def _generate_username(email: str) -> str:
+    """
+    Generate a unique username from the email prefix.
+
+    Strategy:
+      1. Take everything before the @ sign.
+      2. Keep only alphanumeric chars and underscores.
+      3. If that username is taken, append a 6-char UUID fragment.
+      4. Truncate to 50 chars (User.username max_length).
+
+    Examples:
+      john.doe@gmail.com  → john_doe
+      john.doe@gmail.com  → john_doe_a3f9c2  (if john_doe exists)
+    """
+    prefix = email.split("@")[0]
+    # Replace non-alphanumeric (except underscore) with underscore
+    clean = "".join(c if c.isalnum() or c == "_" else "_" for c in prefix)
+    clean = clean[:44]  # leave room for suffix
+
+    if not User.objects.filter(username=clean).exists():
+        return clean
+
+    # Append short UUID suffix to guarantee uniqueness
+    suffix = uuid.uuid4().hex[:6]
+    return f"{clean}_{suffix}"[:50]

--- a/backend/apps/accounts/urls.py
+++ b/backend/apps/accounts/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from .views import (
     CookieTokenObtainPairView,
     CookieTokenRefreshView,
+    GoogleLoginView,
     LogoutView,
     PasswordChangeView,
     RegisterView,
@@ -16,4 +17,5 @@ urlpatterns = [
     path("token/refresh/", CookieTokenRefreshView.as_view(), name="auth-token-refresh"),
     path("password/change/", PasswordChangeView.as_view(), name="auth-password-change"),
     path("user/", UserView.as_view(), name="auth-user"),
+    path("google/", GoogleLoginView.as_view(), name="auth-google"),
 ]

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -1,7 +1,7 @@
 """
 apps/accounts/views.py
 
-All authentication endpoints for Ticket 1.3.
+All authentication endpoints for Ticket 1.3 + Ticket 1.4.
 
 Design decisions for 2026 production-grade security:
 ──────────────────────────────────────────────────────
@@ -23,6 +23,11 @@ Design decisions for 2026 production-grade security:
 
 5. All errors return the standard envelope via custom_exception_handler.
    Views never return raw strings — they raise DRF exceptions.
+
+6. [Ticket 1.4] Google OAuth uses frontend-driven token exchange.
+   The React frontend gets the id_token from Google directly, then
+   POSTs it to /auth/google/. No server-side redirect flow needed.
+   Verification is done by google-auth library with a 5s timeout.
 """
 
 from django.conf import settings
@@ -40,11 +45,14 @@ from common.exception_handler import (
     REFRESH_COOKIE_MISSING,
 )
 
+from .google import GoogleServiceUnavailable, GoogleTokenInvalid, verify_google_id_token
 from .serializers import (
+    GoogleLoginSerializer,
     PasswordChangeSerializer,
     RegisterSerializer,
     UserPublicSerializer,
 )
+from .services import get_or_create_google_user
 
 
 class UserView(APIView):
@@ -328,3 +336,86 @@ class PasswordChangeView(APIView):
             {"message": "Password changed successfully. Please log in again."},
             status=status.HTTP_200_OK,
         )
+
+
+# ── Google OAuth2 ─────────────────────────────────────────────────────────────
+
+class GoogleLoginView(APIView):
+    """
+    POST /api/v1/auth/google/
+
+    Frontend-driven Google OAuth2 token exchange (system.md §7.2).
+
+    Flow:
+      1. React frontend opens Google consent screen (@react-oauth/google)
+      2. Google returns id_token to the frontend
+      3. Frontend POSTs { "id_token": "..." } to this endpoint
+      4. We verify the id_token against Google's public keys (5s timeout)
+      5. get_or_create_google_user() finds or creates the User record
+      6. Return same access+cookie response shape as /auth/login/
+
+    This means the frontend auth handling code is identical for both
+    email/password and Google login — same response shape, same cookie.
+
+    201 → new user created  { "access": "...", "user": {...}, "created": true }
+    200 → existing user     { "access": "...", "user": {...}, "created": false }
+    401 → { "error_code": "GOOGLE_AUTH_FAILED", ... }   (invalid token)
+    503 → { "error_code": "SERVICE_UNAVAILABLE", ... }  (Google unreachable)
+    """
+
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request, *args, **kwargs):
+        serializer = GoogleLoginSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        raw_id_token = serializer.validated_data["id_token"]
+
+        # ── Step 1: Verify the token with Google ──────────────────────────────
+        try:
+            google_info = verify_google_id_token(raw_id_token)
+        except GoogleServiceUnavailable as exc:
+            # Google's servers are down / timed out — return 503
+            # Frontend should show Google button as disabled
+            raise _GoogleUnavailableException(str(exc)) from exc
+        except GoogleTokenInvalid as exc:
+            # Token is forged, expired, wrong audience, etc.
+            from rest_framework.exceptions import AuthenticationFailed
+            raise AuthenticationFailed(
+                detail=str(exc),
+                code="GOOGLE_AUTH_FAILED",
+            ) from exc
+
+        # ── Step 2: Get or create the user ────────────────────────────────────
+        user, created = get_or_create_google_user(google_info)
+
+        # ── Step 3: Issue JWT tokens ───────────────────────────────────────────
+        access, refresh = _tokens_for_user(user)
+
+        http_status = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        response = Response(
+            {
+                "access": access,
+                "user": UserPublicSerializer(user).data,
+                "created": created,
+            },
+            status=http_status,
+        )
+        _set_refresh_cookie(response, refresh, request)
+        return response
+
+
+class _GoogleUnavailableException(Exception):
+    """
+    Internal exception for Google service unavailability.
+    Caught by custom_exception_handler and mapped to 503.
+
+    We subclass plain Exception (not a DRF exception) so we can
+    attach a custom status_code that the exception handler reads.
+    """
+    status_code = 503
+    default_code = "SERVICE_UNAVAILABLE"
+
+    def __init__(self, message: str):
+        self.detail = message
+        super().__init__(message)


### PR DESCRIPTION
- Add POST /api/v1/auth/google/ endpoint for frontend-driven token exchange
- Verify id_token against Google's public keys with 5s timeout
- Create or login existing user with auth_provider='google'
- Return same access token + refresh cookie as email login
- Add PasswordChangeView rejection for Google users
- Add 503 handling for Google service unavailability